### PR TITLE
fix version requirement to use correct syntax

### DIFF
--- a/t/lib/MyApp.pm
+++ b/t/lib/MyApp.pm
@@ -1,5 +1,5 @@
 package MyApp;
-use Catalyst::Runtime '5.70';
+use Catalyst::Runtime 5.70;
 use Catalyst;
 use Carp;
 use Data::Dump qw( dump );


### PR DESCRIPTION
Version numbers on a use line need to be unquoted to be handled properly. When they are quoted, they are passed in import instead. Part versions of perl ignored these arguments, but future versions are intending to throw errors for arguments given to an undefined import method.